### PR TITLE
Add default export name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@ export {
 export {
   schema,
 } from "./webauthn-schema";
+
+export default WebAuthnJSON;


### PR DESCRIPTION
What do you think about adding a default export name, so as it can be imported like this ?

`import WebAuthnJSON from '@github/webauthn-json';`