### PR TITLE
Update extended module info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Modern browsers generally only support a small numbe rof extensions. To save cod
 - `appid`
 - `appidExclude`
 
-If you need to convert additional input or output extensions, use `createExtended()` and `getExtended()` from `@github/webauthn-json/dist/extended`.
+If you need to convert additional input or output extensions, use `createExtended()` and `getExtended()` from `@github/webauthn-json/extended`.
 
 ## Contributions
 


### PR DESCRIPTION
## What

The docs were stating that the extended module was imported using

```javascript
import @github/webauthn-json/dist/extended
```

although after updating from `v0.4.5` to `v0.5.3` that changed and now I have to import it using 

```javascript
import @github/webauthn-json/extended
```

which imo is cleaner btw 🙂 


So this PR just attempts to update the docs with that change.


