### PR TITLE
Pass through AuthenticatorAttestationResponse.getTransports()

### DIFF
--- a/src/basic/api.ts
+++ b/src/basic/api.ts
@@ -5,7 +5,6 @@ import {
   CredentialRequestOptionsJSON,
   PublicKeyCredentialWithAssertionJSON,
   PublicKeyCredentialWithAttestationJSON,
-  PublicKeyCredentialWithClientExtensionResults,
 } from "./json";
 import {
   credentialCreationOptions,
@@ -23,12 +22,10 @@ export function createRequestFromJSON(
 export function createResponseToJSON(
   credential: PublicKeyCredential,
 ): PublicKeyCredentialWithAttestationJSON {
-  const credentialWithClientExtensionResults = credential as PublicKeyCredentialWithClientExtensionResults;
-  credentialWithClientExtensionResults.clientExtensionResults = credential.getClientExtensionResults();
   return convert(
     bufferToBase64url,
     publicKeyCredentialWithAttestation,
-    credentialWithClientExtensionResults,
+    credential,
   );
 }
 
@@ -50,12 +47,10 @@ export function getRequestFromJSON(
 export function getResponseToJSON(
   credential: PublicKeyCredential,
 ): PublicKeyCredentialWithAssertionJSON {
-  const credentialWithClientExtensionResults = credential as PublicKeyCredentialWithClientExtensionResults;
-  credentialWithClientExtensionResults.clientExtensionResults = credential.getClientExtensionResults();
   return convert(
     bufferToBase64url,
     publicKeyCredentialWithAssertion,
-    credentialWithClientExtensionResults,
+    credential,
   );
 }
 

--- a/src/basic/json.ts
+++ b/src/basic/json.ts
@@ -76,6 +76,7 @@ export interface CredentialCreationOptionsJSON {
 export interface AuthenticatorAttestationResponseJSON {
   clientDataJSON: Base64urlString;
   attestationObject: Base64urlString;
+  transports: string[];
 }
 
 export interface PublicKeyCredentialWithAttestationJSON {

--- a/src/basic/schema.ts
+++ b/src/basic/schema.ts
@@ -59,6 +59,10 @@ export const publicKeyCredentialWithAttestation: Schema = {
   response: required({
     clientDataJSON: required(convert),
     attestationObject: required(convert),
+    transports: derived(
+      copy,
+      (response: any) => response.getTransports?.() || [],
+    ),
   }),
   clientExtensionResults: derived(
     simplifiedClientExtensionResultsSchema,

--- a/src/basic/schema.ts
+++ b/src/basic/schema.ts
@@ -2,6 +2,7 @@ import { Schema } from "../schema-format";
 import {
   convertValue as convert,
   copyValue as copy,
+  derived,
   optional,
   required,
 } from "../convert";
@@ -59,7 +60,10 @@ export const publicKeyCredentialWithAttestation: Schema = {
     clientDataJSON: required(convert),
     attestationObject: required(convert),
   }),
-  clientExtensionResults: required(simplifiedClientExtensionResultsSchema),
+  clientExtensionResults: derived(
+    simplifiedClientExtensionResultsSchema,
+    (pkc: PublicKeyCredential) => pkc.getClientExtensionResults(),
+  ),
 };
 
 // `navigator.get()` request
@@ -89,7 +93,10 @@ export const publicKeyCredentialWithAssertion: Schema = {
     signature: required(convert),
     userHandle: required(convert),
   }),
-  clientExtensionResults: required(simplifiedClientExtensionResultsSchema),
+  clientExtensionResults: derived(
+    simplifiedClientExtensionResultsSchema,
+    (pkc: PublicKeyCredential) => pkc.getClientExtensionResults(),
+  ),
 };
 
 export const schema: { [s: string]: Schema } = {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,7 +1,7 @@
 // We export these values in order so that they can be used to deduplicate
 // schema definitions in minified JS code.
 
-import { Schema } from "./schema-format";
+import { Schema, SchemaProperty } from "./schema-format";
 
 // TODO: Parcel isn't deduplicating these values.
 export const copyValue = "copy";
@@ -47,14 +47,14 @@ export function convert<From, To>(
   }
 }
 
-export function required(schema: Schema): any {
+export function required(schema: Schema): SchemaProperty {
   return {
     required: true,
     schema,
   };
 }
 
-export function optional(schema: Schema): any {
+export function optional(schema: Schema): SchemaProperty {
   return {
     required: false,
     schema,

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -24,6 +24,13 @@ export function convert<From, To>(
   if (schema instanceof Object) {
     const output: any = {};
     for (const [key, schemaField] of Object.entries(schema)) {
+      if (schemaField.deriveFn) {
+        const v = schemaField.deriveFn(input);
+        if (v !== undefined) {
+          input[key] = v;
+        }
+      }
+
       if (!(key in input)) {
         if (schemaField.required) {
           throw new Error(`Missing key: ${key}`);
@@ -45,6 +52,17 @@ export function convert<From, To>(
     }
     return output;
   }
+}
+
+export function derived(
+  schema: Schema,
+  deriveFn: (v: any) => any,
+): SchemaProperty {
+  return {
+    required: true,
+    schema,
+    deriveFn,
+  };
 }
 
 export function required(schema: Schema): SchemaProperty {

--- a/src/extended/api.ts
+++ b/src/extended/api.ts
@@ -4,10 +4,7 @@ import {
   Base64urlString,
 } from "../base64url";
 import { convert } from "../convert";
-import {
-  PublicKeyCredentialWithClientExtensionResults,
-  AuthenticatorAttestationResponseJSON,
-} from "../basic/json";
+import { AuthenticatorAttestationResponseJSON } from "../basic/json";
 import {
   CredentialCreationOptionsExtendedJSON,
   CredentialRequestOptionsExtendedJSON,
@@ -38,12 +35,10 @@ export function createExtendedRequestFromJSON(
 export function createExtendedResponseToJSON(
   credential: PublicKeyCredential,
 ): PublicKeyCredentialWithAttestationExtendedResultsJSON {
-  const credentialWithClientExtensionResults = credential as PublicKeyCredentialWithClientExtensionResults;
-  credentialWithClientExtensionResults.clientExtensionResults = credential.getClientExtensionResults();
   return convert(
     bufferToBase64url,
     publicKeyCredentialWithAttestationExtended,
-    credentialWithClientExtensionResults,
+    credential,
   );
 }
 
@@ -119,12 +114,10 @@ export function getExtendedRequestFromJSON(
 export function getExtendedResponseToJSON(
   credential: PublicKeyCredential,
 ): PublicKeyCredentialWithAssertionExtendedResultsJSON {
-  const credentialWithClientExtensionResults = credential as PublicKeyCredentialWithClientExtensionResults;
-  credentialWithClientExtensionResults.clientExtensionResults = credential.getClientExtensionResults();
   return convert(
     bufferToBase64url,
     publicKeyCredentialWithAssertionExtended,
-    credentialWithClientExtensionResults,
+    credential,
   );
 }
 

--- a/src/extended/schema.ts
+++ b/src/extended/schema.ts
@@ -49,6 +49,7 @@ export const publicKeyCredentialWithAttestationExtended: Schema = JSON.parse(
   authenticationExtensionsClientOutputsSchema,
   (publicKeyCredentialWithAttestation as any).clientExtensionResults.deriveFn,
 );
+(publicKeyCredentialWithAttestationExtended as any).response.schema.transports = (publicKeyCredentialWithAttestation as any).response.schema.transports;
 // get
 
 export const credentialRequestOptionsExtended: Schema = JSON.parse(

--- a/src/extended/schema.ts
+++ b/src/extended/schema.ts
@@ -4,7 +4,7 @@ import {
   publicKeyCredentialWithAssertion,
   publicKeyCredentialWithAttestation,
 } from "../basic/schema";
-import { convertValue, copyValue, optional, required } from "../convert";
+import { convertValue, copyValue, derived, optional } from "../convert";
 import { Schema } from "../schema-format";
 
 // shared
@@ -45,8 +45,9 @@ export const credentialCreationOptionsExtended: Schema = JSON.parse(
 export const publicKeyCredentialWithAttestationExtended: Schema = JSON.parse(
   JSON.stringify(publicKeyCredentialWithAttestation),
 );
-(publicKeyCredentialWithAttestationExtended as any).clientExtensionResults = required(
+(publicKeyCredentialWithAttestationExtended as any).clientExtensionResults = derived(
   authenticationExtensionsClientOutputsSchema,
+  (publicKeyCredentialWithAttestation as any).clientExtensionResults.deriveFn,
 );
 // get
 
@@ -60,6 +61,7 @@ export const credentialRequestOptionsExtended: Schema = JSON.parse(
 export const publicKeyCredentialWithAssertionExtended: Schema = JSON.parse(
   JSON.stringify(publicKeyCredentialWithAssertion),
 );
-(publicKeyCredentialWithAssertionExtended as any).clientExtensionResults = required(
+(publicKeyCredentialWithAssertionExtended as any).clientExtensionResults = derived(
   authenticationExtensionsClientOutputsSchema,
+  (publicKeyCredentialWithAssertion as any).clientExtensionResults.deriveFn,
 );

--- a/src/schema-format.ts
+++ b/src/schema-format.ts
@@ -1,6 +1,10 @@
 type SchemaLeaf = "copy" | "convert";
+export interface SchemaProperty {
+  required: boolean;
+  schema: Schema;
+}
 interface SchemaObject {
-  [property: string]: { required: boolean; schema: Schema };
+  [property: string]: SchemaProperty;
 }
 type SchemaArray = [SchemaObject] | [SchemaLeaf];
 

--- a/src/schema-format.ts
+++ b/src/schema-format.ts
@@ -2,6 +2,7 @@ type SchemaLeaf = "copy" | "convert";
 export interface SchemaProperty {
   required: boolean;
   schema: Schema;
+  deriveFn?(v: any): any;
 }
 interface SchemaObject {
   [property: string]: SchemaProperty;

--- a/test/extended.spec.ts
+++ b/test/extended.spec.ts
@@ -1,6 +1,11 @@
 import { base64urlToBuffer } from "../src/base64url";
 import { CredentialCreationOptionsExtendedJSON } from "../src/extended/json";
+import { PublicKeyCredentialWithClientExtensionResults } from "../src/basic/json";
 import { credentialCreationOptionsExtended } from "../src/extended/schema";
+import {
+  createExtendedResponseToJSON,
+  getExtendedResponseToJSON,
+} from "../src/extended/api";
 import { convert } from "../src/convert";
 import "./arraybuffer";
 
@@ -74,5 +79,81 @@ describe("extended schema", () => {
         0xe0,
       ]),
     );
+  });
+
+  test("converts PublicKeyCredentialWithClientExtensionResults with attestation", () => {
+    const pkcwa: PublicKeyCredentialWithClientExtensionResults = {
+      type: "public-key",
+      id:
+        "URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENT",
+      rawId: new Uint8Array([1, 2, 3, 4]),
+      response: {
+        clientDataJSON: new Uint8Array([9, 10, 11, 12]),
+        attestationObject: new Uint8Array([13, 14, 15, 16]),
+      } as AuthenticatorAttestationResponse,
+      getClientExtensionResults: () =>
+        ({
+          appidExclude: true,
+          largeBlob: {
+            supported: true,
+          },
+        } as AuthenticationExtensionsClientOutputs),
+    };
+    const converted = createExtendedResponseToJSON(pkcwa);
+    expect(converted).toEqual({
+      type: "public-key",
+      id:
+        "URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENT",
+      rawId: "AQIDBA",
+      response: {
+        attestationObject: "DQ4PEA",
+        clientDataJSON: "CQoLDA",
+      },
+      clientExtensionResults: {
+        appidExclude: true,
+        largeBlob: {
+          supported: true,
+        },
+      },
+    });
+  });
+
+  test("converts PublicKeyCredentialWithClientExtensionResults with assertion", () => {
+    const pkcwa: PublicKeyCredentialWithClientExtensionResults = {
+      type: "public-key",
+      id:
+        "URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENT",
+      rawId: new Uint8Array([1, 2, 3, 4]),
+      response: {
+        authenticatorData: new Uint8Array([5, 6, 7, 8]),
+        clientDataJSON: new Uint8Array([9, 10, 11, 12]),
+        signature: new Uint8Array([13, 14, 15, 16]),
+        userHandle: null,
+      } as AuthenticatorAssertionResponse,
+      getClientExtensionResults: () =>
+        ({
+          largeBlob: {
+            written: true,
+          },
+        } as AuthenticationExtensionsClientOutputs),
+    };
+    const converted = getExtendedResponseToJSON(pkcwa);
+    expect(converted).toEqual({
+      type: "public-key",
+      id:
+        "URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENT",
+      rawId: "AQIDBA",
+      response: {
+        authenticatorData: "BQYHCA",
+        clientDataJSON: "CQoLDA",
+        signature: "DQ4PEA",
+        userHandle: null,
+      },
+      clientExtensionResults: {
+        largeBlob: {
+          written: true,
+        },
+      },
+    });
   });
 });

--- a/test/extended.spec.ts
+++ b/test/extended.spec.ts
@@ -90,6 +90,7 @@ describe("extended schema", () => {
       response: {
         clientDataJSON: new Uint8Array([9, 10, 11, 12]),
         attestationObject: new Uint8Array([13, 14, 15, 16]),
+        getTransports: () => ["usb"],
       } as AuthenticatorAttestationResponse,
       getClientExtensionResults: () =>
         ({
@@ -108,6 +109,7 @@ describe("extended schema", () => {
       response: {
         attestationObject: "DQ4PEA",
         clientDataJSON: "CQoLDA",
+        transports: ["usb"],
       },
       clientExtensionResults: {
         appidExclude: true,

--- a/test/webauthn-schema.spec.ts
+++ b/test/webauthn-schema.spec.ts
@@ -93,6 +93,7 @@ describe("webauthn schema", () => {
       response: {
         clientDataJSON: new Uint8Array([9, 10, 11, 12]),
         attestationObject: new Uint8Array([13, 14, 15, 16]),
+        getTransports: () => ["usb"],
       } as AuthenticatorAttestationResponse,
       getClientExtensionResults: () =>
         ({
@@ -115,6 +116,49 @@ describe("webauthn schema", () => {
       response: {
         attestationObject: "DQ4PEA",
         clientDataJSON: "CQoLDA",
+        transports: ["usb"],
+      },
+      clientExtensionResults: {
+        appidExclude: true,
+        credProps: {
+          rk: true,
+        },
+      },
+    });
+  });
+
+  test("converts PublicKeyCredentialWithAttestationJSON in browsers without getTransports()", () => {
+    const pkcwa: PublicKeyCredentialWithClientExtensionResults = {
+      type: "public-key",
+      id:
+        "URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENT",
+      rawId: new Uint8Array([1, 2, 3, 4]),
+      response: {
+        clientDataJSON: new Uint8Array([9, 10, 11, 12]),
+        attestationObject: new Uint8Array([13, 14, 15, 16]),
+      } as AuthenticatorAttestationResponse,
+      getClientExtensionResults: () =>
+        ({
+          appidExclude: true,
+          credProps: {
+            rk: true,
+          },
+        } as AuthenticationExtensionsClientOutputs),
+    };
+    const converted = convert(
+      bufferToBase64url,
+      publicKeyCredentialWithAttestation,
+      pkcwa,
+    );
+    expect(converted).toEqual({
+      type: "public-key",
+      id:
+        "URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENTIAL_ID-URL_SAFE_BASE_64_CREDENT",
+      rawId: "AQIDBA",
+      response: {
+        attestationObject: "DQ4PEA",
+        clientDataJSON: "CQoLDA",
+        transports: [],
       },
       clientExtensionResults: {
         appidExclude: true,

--- a/test/webauthn-schema.spec.ts
+++ b/test/webauthn-schema.spec.ts
@@ -94,13 +94,13 @@ describe("webauthn schema", () => {
         clientDataJSON: new Uint8Array([9, 10, 11, 12]),
         attestationObject: new Uint8Array([13, 14, 15, 16]),
       } as AuthenticatorAttestationResponse,
-      getClientExtensionResults: () => ({}),
-      clientExtensionResults: {
-        appidExclude: true,
-        credProps: {
-          rk: true,
-        },
-      },
+      getClientExtensionResults: () =>
+        ({
+          appidExclude: true,
+          credProps: {
+            rk: true,
+          },
+        } as AuthenticationExtensionsClientOutputs),
     };
     const converted = convert(
       bufferToBase64url,
@@ -232,10 +232,9 @@ describe("webauthn schema", () => {
         signature: new Uint8Array([13, 14, 15, 16]),
         userHandle: null,
       } as AuthenticatorAssertionResponse,
-      getClientExtensionResults: () => ({}),
-      clientExtensionResults: {
+      getClientExtensionResults: () => ({
         appid: true,
-      },
+      }),
     };
     const converted = convert(
       bufferToBase64url,


### PR DESCRIPTION
Fixes one part of #25 .

This includes and builds upon a related change in how `clientExtensionResults` are declared in the schema, by introducing a `derived` option for properties alongside the existing `required` and `optional`. I think this captures the idea a bit more cleanly, and it also allows some test inputs to define `getClientExtensionResults()` instead of injecting a `clientExtensionResults` property. Then the transports field works the same way using this new schema feature. Plumbing it through for the "extended' target gets a bit ugly, but... it's kind of okay I guess?

If you don't agree with that change, I can drop it and rework the `transports` addition to inject a new property in the same way `createExtendedResponseToJSON()` currently does for `clientExtensionResults` for example. The new tests should apply well enough in that case too.

In case the client does not provide the `getTransports()` method, the converter will fall back to returning an empty sequence. This is because the spec says [clients are to return "[...] or an empty sequence if the information is unavailable"][1], so that seems like a sensible fallback value (since the information is indeed unavailable).

[1]: https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#dom-authenticatorattestationresponse-transports-slot
