### PR TITLE
Fix output format for webauthn-json.browser-global.js

### DIFF
--- a/script/build-js.js
+++ b/script/build-js.js
@@ -41,7 +41,7 @@ build({
 
 build({
   entryPoints: ["src/webauthn-json/browser-global.ts"],
-  format: "cjs",
+  format: "iife",
   target: "es6",
   bundle: true,
   sourcemap: true,


### PR DESCRIPTION
`webauthn-json.browser-global.js` in the recent webauthn-json releases uses the CommonJS format which is intended to be used in node, not in browsers. This PR switches the format to "iife", which produces a more browser-friendly output.

I've tested the resulting `webauthn-json.browser-global.js` as a standalone include (`<script src="webauthn-json.browser-global.js">`) in HTML files, and it worked with no issues.

cc: #24 