### PR TITLE
Update npm auth env

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -53,4 +53,4 @@ jobs:
       - run: make build
       - run: npm publish --provenance --access public
         env:
-          NPM_TOKEN: ${{ secrets.NPM_WEBAUTHN_JSON_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WEBAUTHN_JSON_PUBLISH_TOKEN }}


### PR DESCRIPTION
Use the env var `NODE_AUTH_TOKEN` as `actions/setup-node` will auto-magically read this env var in the created `.npmrc` file it creates.

Ref: https://github.com/actions/setup-node/blob/d1b197b965eb46e1a1878caad41c4ab3efae133f/src/authutil.ts#L48