### PR TITLE
Update deprecation notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if (jsonWebAuthnSupport) {
 
 ## Reasoning
 
-`@github/webauthn-json` served as an ecosystem prototype of the functionality was [developed into the built-in browser methods](https://github.com/w3c/webauthn/wiki/Explainer:-JSON-Serialization-Methods). The built-in methods are compatible with `@github/webauthn-json` encoding, so you can use them as a drop-in substitute. We strongly recommend doing so, since:
+`@github/webauthn-json` served as an ecosystem prototype of the functionality that was [developed into the built-in browser methods](https://github.com/w3c/webauthn/wiki/Explainer:-JSON-Serialization-Methods). The built-in methods are compatible with `@github/webauthn-json` encoding, so you can use them as a drop-in substitute. We strongly recommend doing so, since:
 
 - The browser-native JSON parsing functions are already available for the vast majority of users.
 - They are increasingly receiving fields and features (such as user-agent hints and the `prf` extension) that `@github/webauthn-json` will never receive.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ if (jsonWebAuthnSupport) {
 
 `@github/webauthn-json` served as an ecosystem prototype of the functionality was [developed into the built-in browser methods](https://github.com/w3c/webauthn/wiki/Explainer:-JSON-Serialization-Methods). The built-in methods are compatible with `@github/webauthn-json` encoding, so you can use them as a drop-in substitute. We strongly recommend doing so, since:
 
-- The browser-native JSON parsing functions are increasingly receiving fields and features (such as user-agent hints and the `prf` extension) that `@github/webauthn-json` will never receive.
+- The browser-native JSON parsing functions are already available for the vast majority of users.
+- They are increasingly receiving fields and features (such as user-agent hints and the `prf` extension) that `@github/webauthn-json` will never receive.
 - Removing `@github/webauthn-json` from your codebase will remove code from your authentication pages, reducing load times for your users and reducing the chance you will need to debug issues.
 
 ## Fallback (not recommended)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,47 @@
-⚠️ ⚠️ ⚠️
+# ⚠️ `@github/webauthn-json` is deprecated
 
-WebAuthn-json has been sunset. Now that [all major browsers support WebAuthn](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API#browser_compatibility) we recommend invoking the native APIs
+As of March 2025, stable versions of all major browsers now support the following methods:
 
-⚠️ ⚠️ ⚠️
+- [`PublicKeyCredential.parseCreationOptionsFromJSON(…)`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
+- [`PublicKeyCredential.parseRequestOptionsFromJSON(…)`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
+
+By design, these are compatible with `@github/webauthn-json` encoding, so you can use them as a drop-in substitute. We strongly recommend doing so, since:
+
+- The browser-native JSON parsing functions are increasingly receiving fields and features (such as user-agent hints and the `prf` extension) that `@github/webauthn-json` will never receive.
+- Removing `@github/webauthn-json` from your codebase will remove code from your authentication pages, reducing load times for your users and reducing the chance you will need to debug issues.
+
+If you need to support older browsers in the short-term, consider loading this library only as a fallback:
+
+```js
+async function register() {
+  const parseCreationOptionsFromJSON =
+  PublicKeyCredential.parseCreationOptionsFromJSON ??
+    /* @type PublicKeyCredential.parseCreationOptionsFromJSON */
+    (await import("@github/webauthn-json/browser-ponyfill")).parseCreationOptionsFromJSON;
+
+  const publicKey = parseCreationOptionsFromJSON({ /* … */ });
+  return navigator.credentials.create({publicKey});
+}
+
+async function authenticate() {
+  const parseRequestOptionsFromJSON =
+    PublicKeyCredential.parseRequestOptionsFromJSON ??
+      /* @type PublicKeyCredential.parseRequestOptionsFromJSON */
+      (await import("@github/webauthn-json/browser-ponyfill")).parseRequestOptionsFromJSON;
+
+  const publicKey = parseRequestOptionsFromJSON({ /* … */ });
+  return navigator.credentials.get({publicKey});
+}
+```
+
+<br>
+<br>
+
+This project's old README contents are below:
+
+<br>
+
+--------
 
 # `@github/webauthn-json`
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ As of March 2025, stable versions of all major browsers now support the followin
 
 - [`PublicKeyCredential.parseCreationOptionsFromJSON(…)`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
 - [`PublicKeyCredential.parseRequestOptionsFromJSON(…)`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
+- [`PublicKeyCredential` → `.toJSON()`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential)
 
 These should be used instead of `@github/webauthn-json`.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 As of March 2025, stable versions of all major browsers now support the following methods:
 
-- [`PublicKeyCredential.parseCreationOptionsFromJSON(…)`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
-- [`PublicKeyCredential.parseRequestOptionsFromJSON(…)`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
-- [`PublicKeyCredential` → `.toJSON()`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential)
+- [`PublicKeyCredential.parseCreationOptionsFromJSON(…)`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
+- [`PublicKeyCredential.parseRequestOptionsFromJSON(…)`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static)
+- [`PublicKeyCredential` → `.toJSON()`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential)
 
 These should be used instead of `@github/webauthn-json`.
 


### PR DESCRIPTION
It now:

- Links to the built-in JSON parsing functions on MDN (which contain explanations, examples, and links to specs).
- Contains an obvious example that is ready to copy, with some conveniences and guiderails. In particular:
  - Avoids top-level `await` (which is well-supported by browsers but still errors in TypeScript unless you specifically configure it).
  - Includes TypeScript annotations to help make it easy to use the code without hacks.
- Provides encouragement and rationale to stop using `@github/webauthn-json`.
- Includes a fallback example, both as a pragmatic compromise but also to illustrate the tradeoffs vs. completely moving off the library.